### PR TITLE
Support for Lua 5.2

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -1,0 +1,12 @@
+#ifndef COMPAT_H
+#define COMPAT_H
+
+#if (LUA_VERSION_NUM == 502)
+#undef luaL_register
+#define luaL_register(L,n,f) \
+                { if ((n) == NULL) luaL_setfuncs(L,f,0); else luaL_newlib(L,f); }
+
+#endif
+
+#endif
+

--- a/src/context.c
+++ b/src/context.c
@@ -11,6 +11,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 
+#include "compat.h"
 #include "context.h"
 #include "options.h"
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12,6 +12,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 
+#include "compat.h"
 #include "io.h"
 #include "buffer.h"
 #include "timeout.h"

--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -4,14 +4,13 @@
 --
 ------------------------------------------------------------------------------
 
-module("ssl", package.seeall)
+local core    = require("ssl.core")
+local context = require("ssl.context")
 
-require("ssl.core")
-require("ssl.context")
+local M = {}
 
-
-_VERSION   = "0.4.1"
-_COPYRIGHT = "LuaSec 0.4.1 - Copyright (C) 2006-2011 Bruno Silvestre\n" .. 
+M._VERSION   = "0.4.1"
+M._COPYRIGHT = "LuaSec 0.4.1 - Copyright (C) 2006-2011 Bruno Silvestre\n" .. 
              "LuaSocket 2.0.2 - Copyright (C) 2004-2007 Diego Nehab"
 
 -- Export functions
@@ -35,7 +34,7 @@ end
 --
 --
 --
-function newcontext(cfg)
+function M.newcontext(cfg)
    local succ, msg, ctx
    -- Create the context
    ctx, msg = context.create(cfg.protocol)
@@ -75,10 +74,10 @@ end
 --
 --
 --
-function wrap(sock, cfg)
+function M.wrap(sock, cfg)
    local ctx, msg
    if type(cfg) == "table" then
-      ctx, msg = newcontext(cfg)
+      ctx, msg = M.newcontext(cfg)
       if not ctx then return nil, msg end
    else
       ctx = cfg
@@ -91,3 +90,6 @@ function wrap(sock, cfg)
    end
    return nil, msg 
 end
+
+return M
+


### PR DESCRIPTION
Lua 5.1 is still supported and working with this change.

I did make a change to ssl.lua to remove module() and replace it with putting the public functions in a table and returning the table. This may break existing scripts that rely on require putting ssl in to the global environment.
