### PR TITLE
Report the actual TLS version used, not the version the cipher belongs to.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -645,7 +645,8 @@ static int meth_info(lua_State *L)
   lua_pushstring(L, buf);
   lua_pushnumber(L, bits);
   lua_pushnumber(L, algbits);
-  return 3;
+  lua_pushstring(L, SSL_get_version(ssl->ssl));
+  return 4;
 }
 
 static int meth_copyright(lua_State *L)

--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -128,7 +128,7 @@ end
 -- Extract connection information.
 --
 local function info(ssl, field)
-  local str, comp, err 
+  local str, comp, err, protocol
   comp, err = core.compression(ssl)
   if err then
     return comp, err
@@ -138,13 +138,16 @@ local function info(ssl, field)
     return comp
   end
   local info = {compression = comp}
-  str, info.bits, info.algbits = core.info(ssl)
+  str, info.bits, info.algbits, protocol = core.info(ssl)
   if str then
     info.cipher, info.protocol, info.key,
     info.authentication, info.encryption, info.mac =
         string.match(str, 
           "^(%S+)%s+(%S+)%s+Kx=(%S+)%s+Au=(%S+)%s+Enc=(%S+)%s+Mac=(%S+)")
     info.export = (string.match(str, "%sexport%s*$") ~= nil)
+  end
+  if protocol then
+    info.protocol = protocol
   end
   if field then
     return info[field]


### PR DESCRIPTION
`:info("protocol")` does not return the TLS version used for a connection, it returns the TLS version where the cipher was introduced in. This is because `:info()` parses the cipher info, which is a static string for every cipher (see the output of "openssl ciphers -V").

By using `SSL_get_version` it is possible to get the actual TLS version used for a connection. This pull request implements that, with a fallback to the cipher's protocol.
