### PR TITLE
x509: Handle non-UTF8 ASN1 strings correctly by converting them to UTF8.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -77,7 +77,7 @@ static void push_asn1_string(lua_State* L, ASN1_STRING *string)
 {
   if (string) {
     unsigned char *data;
-    size_t len = ASN1_STRING_to_UTF8(&data, string);
+    int len = ASN1_STRING_to_UTF8(&data, string);
 
     if (len >= 0) {
       lua_pushlstring(L, (char *)data, len);


### PR DESCRIPTION
Certificates containing `T61STRING` fields are not decoded properly. For example, `:subject().stateOrProvinceName` shows up as: "Baden-W�rttemberg" instead of "Baden-Württemberg" on this certificate: https://gist.github.com/xnyhps/6678389.

This pull request fixes that by always converting the string to UTF8 before pushing it on the Lua stack.
