### PR TITLE
Zash/pubkey

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -506,6 +506,7 @@ static luaL_Reg methods[] = {
   {"notbefore",  meth_notbefore},
   {"notafter",   meth_notafter},
   {"pem",        meth_pem},
+  {"pubkey",     meth_pubkey},
   {"serial",     meth_serial},
   {"subject",    meth_subject},
   {"validat",    meth_valid_at},


### PR DESCRIPTION
This lets you extract the public key in PEM format, along with type (eg RSA, DSA etc) and size in bits.

```
local pubkey, key_type, key_size = cert:pubkey();
print("This certificate has a ".. key_size .. "-bit " .. key_type .. " key.") -- eg 4096-bit RSA key
print(pubkey);
```

(Re-doing as it looks like I broke the other branch)
