### PR TITLE
Method for checking if one certificate issued another

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -400,8 +400,13 @@ static int meth_issued(lua_State *L)
 {
   X509* issuer = lsec_checkx509(L, 1);
   X509* subject = lsec_checkx509(L, 2);
-	lua_pushboolean(L, X509_check_issued(issuer, subject) == X509_V_OK);
-	return 1;
+  int ret = X509_check_issued(issuer, subject);
+  lua_pushboolean(L, ret == X509_V_OK);
+  if (ret != X509_V_OK) {
+    lua_pushstring(L, X509_verify_cert_error_string(ret));
+    return 2;
+  }
+  return 1;
 }
 
 /**

--- a/src/x509.c
+++ b/src/x509.c
@@ -394,6 +394,17 @@ static int meth_notafter(lua_State *L)
 }
 
 /**
+ * Check if this certificate issued some other certificate
+ */
+static int meth_issued(lua_State *L)
+{
+  X509* issuer = lsec_checkx509(L, 1);
+  X509* subject = lsec_checkx509(L, 2);
+	lua_pushboolean(L, X509_check_issued(issuer, subject) == X509_V_OK);
+	return 1;
+}
+
+/**
  * Collect X509 objects.
  */
 static int meth_destroy(lua_State* L)
@@ -459,6 +470,7 @@ static luaL_Reg methods[] = {
   {"issuer",     meth_issuer},
   {"notbefore",  meth_notbefore},
   {"notafter",   meth_notafter},
+  {"issued",     meth_issued},
   {"pem",        meth_pem},
   {"serial",     meth_serial},
   {"subject",    meth_subject},


### PR DESCRIPTION
This lets you check if one certificate was issued by another one.

    > print(parent:issued(child))
    true

The backing OpenSSL function is undocumented and I believe that it performs only issuer name matching and signature verification.  E.g. Basic Constraints seem to be ignored.

I needed this for doing DANE-TA (usage 2) as part of my DANE implementation for Prosody.

Thoughts?  I'm not sure this is ready for merging, so I would like some feedback on if this is something useful.  