### PR TITLE
iPAddress encoding

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -88,8 +88,10 @@ static void push_asn1_string(lua_State* L, ASN1_STRING *string, int encode)
 {
   int len;
   unsigned char *data;
-  if (!string)
+  if (!string) {
     lua_pushnil(L);
+    return;
+  }
   switch (encode) {
   case LSEC_AI5_STRING:
     lua_pushlstring(L, (char*)ASN1_STRING_data(string),

--- a/src/x509.c
+++ b/src/x509.c
@@ -262,7 +262,7 @@ int meth_extensions(lua_State* L)
       case GEN_IPADD:
         lua_pushstring(L, "iPAddress");
         push_subtable(L, -2);
-        push_asn1_string(L, general_name->d.iPAddress, px->encode);
+        push_asn1_string(L, general_name->d.iPAddress, LSEC_AI5_STRING);
         lua_rawseti(L, -2, lua_rawlen(L, -2)+1);
         lua_pop(L, 1);
         break;

--- a/src/x509.c
+++ b/src/x509.c
@@ -101,6 +101,8 @@ static void push_asn1_string(lua_State* L, ASN1_STRING *string, int encode)
       lua_pushlstring(L, (char*)data, len);
       OPENSSL_free(data);
     }
+    else
+      lua_pushnil(L);
   }
 }
 


### PR DESCRIPTION
Calling `x509cert:extensions()` on a certificate containing iPAddress SANs will return those IP addresses as raw bytes.

Additionally, if combined with `x509cert:setencode("utf8")`, the `ASN1_STRING_to_UTF8()` call will fail and nothing will be pushed.

The first first 3 commits fixes issues by returning nil instead of something invalid. The last commit uses `inet_ntop()` to convert IP addresses to the common string form.