### PR TITLE
Don't use deprecated module function

### DIFF
--- a/src/https.lua
+++ b/src/https.lua
@@ -20,13 +20,13 @@ local type         = type
 local pairs        = pairs
 local getmetatable = getmetatable
 
-module("ssl.https")
+local _M = {}
 
-_VERSION   = "0.5"
-_COPYRIGHT = "LuaSec 0.5 - Copyright (C) 2009-2014 PUC-Rio"
+_M._VERSION   = "0.5"
+_M._COPYRIGHT = "LuaSec 0.5 - Copyright (C) 2009-2014 PUC-Rio"
 
 -- Default settings
-PORT = 443
+_M.PORT = 443
 
 local cfg = {
   protocol = "tlsv1",
@@ -40,7 +40,7 @@ local cfg = {
 
 -- Insert default HTTPS port.
 local function default_https_port(u)
-   return url.build(url.parse(u, {port = PORT}))
+   return url.build(url.parse(u, {port = _M.PORT}))
 end
 
 -- Convert an URL to a table according to Luasocket needs.
@@ -113,7 +113,7 @@ end
 -- @param body optional (string)
 -- @return (string if url == string or 1), code, headers, status
 --
-function request(url, body)
+function _M.request(url, body)
   local result_table = {}
   local stringrequest = type(url) == "string"
   if stringrequest then
@@ -136,3 +136,5 @@ function request(url, body)
   end
   return res, code, headers, status
 end
+
+return _M

--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -8,10 +8,10 @@ local core    = require("ssl.core")
 local context = require("ssl.context")
 local x509    = require("ssl.x509")
 
-module("ssl", package.seeall)
+local _M = {}
 
-_VERSION   = "0.5"
-_COPYRIGHT = core.copyright()
+_M._VERSION   = "0.5"
+_M._COPYRIGHT = core.copyright()
 
 -- Export
 loadcertificate = x509.load
@@ -37,7 +37,7 @@ end
 --
 --
 --
-function newcontext(cfg)
+function _M.newcontext(cfg)
    local succ, msg, ctx
    -- Create the context
    ctx, msg = context.create(cfg.protocol)
@@ -115,10 +115,10 @@ end
 --
 --
 --
-function wrap(sock, cfg)
+function _M.wrap(sock, cfg)
    local ctx, msg
    if type(cfg) == "table" then
-      ctx, msg = newcontext(cfg)
+      ctx, msg = _M.newcontext(cfg)
       if not ctx then return nil, msg end
    else
       ctx = cfg
@@ -170,3 +170,4 @@ end
 --
 core.setmethod("info", info)
 
+return _M


### PR DESCRIPTION
Since module was deprecated in 5.2 and not available in some installations, use 'explicitly return' approach.