### PR TITLE
Don't set globals from C

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -737,7 +737,7 @@ LSEC_API int luaopen_ssl_context(lua_State *L)
   lua_setfield(L, -2, "__index");
 
   /* Register the module */
-  luaL_register(L, "ssl.context", funcs);
+  luaL_register(L, NULL, funcs);
   return 1;
 }
 #else

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -842,7 +842,7 @@ LSEC_API int luaopen_ssl_core(lua_State *L)
   luaL_register(L, NULL, methods);
   lua_setfield(L, -2, "__index");
 
-  luaL_register(L, "ssl.core", funcs);
+  luaL_register(L, NULL, funcs);
 
   return 1;
 }

--- a/src/x509.c
+++ b/src/x509.c
@@ -578,7 +578,7 @@ LSEC_API int luaopen_ssl_x509(lua_State *L)
   luaL_register(L, NULL, methods);
   lua_setfield(L, -2, "__index");
 
-  luaL_register(L, "ssl.x509", funcs);
+  luaL_register(L, NULL, funcs);
 
   return 1;
 }


### PR DESCRIPTION
The removal of `module()` doesn't stop `luaL_register()` from creating a global `ssl` table which confuses some code that still expects that to exist. This removes it for good and that old code will break and have to be fixed.