### PR TITLE
Implements redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/src/*.o
+/src/luasocket/*.o
+/ssl.dll

--- a/luasec-0.5-3.rockspec
+++ b/luasec-0.5-3.rockspec
@@ -1,0 +1,98 @@
+package = "LuaSec"
+version = "0.5-3"
+source = {
+   url = "git://github.com/brunoos/luasec.git",
+   tag = "luasec-0.5"
+}
+description = {
+   summary = "A binding for OpenSSL library to provide TLS/SSL communication over LuaSocket.",
+   detailed = "This version delegates to LuaSocket the TCP connection establishment between the client and server. Then LuaSec uses this connection to start a secure TLS/SSL session.",
+   homepage = "https://github.com/brunoos/luasec/wiki",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1", "luasocket"
+}
+external_dependencies = {
+   platforms = {
+      unix = {
+         OPENSSL = {
+            header = "openssl/ssl.h",
+            library = "ssl"
+         }
+      },
+      windows = {
+         OPENSSL = {
+            header = "openssl/ssl.h",
+         }
+      },
+   }
+}
+build = {
+   type = "builtin",
+   copy_directories = {
+      "samples"
+   },
+   platforms = {
+      unix = {
+         install = {
+            lib = {
+               "ssl.so"
+            },
+            lua = {
+               "src/ssl.lua", ['ssl.https'] = "src/https.lua"
+            }
+         },
+         modules = {
+            ssl = {
+               incdirs = {
+                  "$(OPENSSL_INCDIR)", "src/", "src/luasocket",
+               },
+               libdirs = {
+                  "$(OPENSSL_LIBDIR)"
+               },
+               libraries = {
+                  "ssl", "crypto"
+               },
+               sources = {
+                  "src/x509.c", "src/context.c", "src/ssl.c", 
+                  "src/luasocket/buffer.c", "src/luasocket/io.c",
+                  "src/luasocket/timeout.c", "src/luasocket/usocket.c"
+               }
+            }
+         }
+      },
+      windows = {
+         install = {
+            lib = {
+               "ssl.dll"
+            },
+            lua = {
+               "src/ssl.lua", ['ssl.https'] = "src/https.lua"
+            }
+         },
+         modules = {
+            ssl = {
+               defines = {
+                  "WIN32", "NDEBUG", "_WINDOWS", "_USRDLL", "LSEC_EXPORTS", "BUFFER_DEBUG", "LSEC_API=__declspec(dllexport)"
+               },
+               libdirs = {
+                  "$(OPENSSL_LIBDIR)",
+                  "$(OPENSSL_BINDIR)",
+               },
+               libraries = {
+                  "libeay32", "ssleay32", "ws2_32"
+               },
+               incdirs = {
+                  "$(OPENSSL_INCDIR)", "src/", "src/luasocket"
+               },
+               sources = {
+                  "src/x509.c", "src/context.c", "src/ssl.c", 
+                  "src/luasocket/buffer.c", "src/luasocket/io.c",
+                  "src/luasocket/timeout.c", "src/luasocket/wsocket.c"
+               }
+            }
+         }
+      }
+   }
+}

--- a/src/https.lua
+++ b/src/https.lua
@@ -13,7 +13,6 @@ local http   = require("socket.http")
 local url    = require("socket.url")
 
 local table  = require("table")
-local string = require("string")
 
 local try          = socket.try
 local type         = type
@@ -38,15 +37,21 @@ local cfg = {
 -- Auxiliar Functions
 --------------------------------------------------------------------
 
--- Insert default HTTPS port.
-local function default_https_port(u)
-   return url.build(url.parse(u, {port = PORT}))
+-- Insert default port.
+local function default_port(u)
+  u = url.parse(u)
+  if u.scheme == "https" then
+    u.port = u.port or PORT
+  else
+    u.port = u.port or http.PORT
+  end  
+  return url.build(u)
 end
 
 -- Convert an URL to a table according to Luasocket needs.
 local function urlstring_totable(url, body, result_table)
    url = {
-      url = default_https_port(url),
+      url = default_port(url),
       method = body and "POST" or "GET",
       sink = ltn12.sink.table(result_table)
    }
@@ -125,7 +130,7 @@ function request(url, body)
   if stringrequest then
     url = urlstring_totable(url, body, result_table)
   else
-    url.url = default_https_port(url.url)
+    url.url = default_port(url.url)
   end
   if http.PROXY or url.proxy then
     return nil, "proxy not supported"


### PR DESCRIPTION
Fixes #34, but depends on a PR for LuaSocket (https://github.com/diegonehab/luasocket/pull/133) to export more information.

With this PR the `https.request` method will work for both `http` and `https` calls and allow redirects (also for changing schemes; http <-> https, in the redirect).

By default it will not allow https -> http redirect, and fail with a security error in that case; `Unallowed insecure redirect https to http`. If the `redirect` field in the request is set to `"all"`, then the redirect https -> http will be allowed and executed.

Some simple test code;
```lua
local https = require("ssl.https")

local function doreq(url)
  local reqt = {
      url = url,
      --redirect = "all",     --> allows https-> http redirect
      target = {},
  }
  reqt.sink = ltn12.sink.table(reqt.target)

  local result, code, headers, status = https.request(reqt)
  print("Fetching:",url,"==>",code, status)
  if headers then
    print("HEADERS")
    for k,v in pairs(headers) do print("",k,v) end
  end
  return result, code, headers, status
end

--local result, code, headers, status = doreq("http://goo.gl/UBCUc5")   -- http --> https redirect
local result, code, headers, status = doreq("https://goo.gl/UBCUc5")  -- https --> https redirect
--local result, code, headers, status = doreq("https://goo.gl/tBfqNu")  -- https --> http security test case
````