### PR TITLE
Rename 0.6a to 0.6alpha

### DIFF
--- a/luasec-0.6alpha-1.rockspec
+++ b/luasec-0.6alpha-1.rockspec
@@ -2,7 +2,7 @@ package = "LuaSec"
 version = "0.6alpha-1"
 source = {
    url = "git://github.com/brunoos/luasec.git",
-   tag = "luasec-0.6alpha"
+   tag = "luasec-0.6a"
 }
 description = {
    summary = "A binding for OpenSSL library to provide TLS/SSL communication over LuaSocket.",

--- a/luasec-0.6alpha-1.rockspec
+++ b/luasec-0.6alpha-1.rockspec
@@ -1,8 +1,8 @@
 package = "LuaSec"
-version = "0.6a-1"
+version = "0.6alpha-1"
 source = {
    url = "git://github.com/brunoos/luasec.git",
-   tag = "luasec-0.6a"
+   tag = "luasec-0.6alpha"
 }
 description = {
    summary = "A binding for OpenSSL library to provide TLS/SSL communication over LuaSocket.",


### PR DESCRIPTION
For the LuaRocks versioning algorithm, `0.6a` > `0.6`, but `0.6alpha` < `0.6`. It recognizes `alpha` < `beta` < `rc`, but other letter suffixes are recognized as greater than numbers (e.g. `1.0k` > `1.0g` > `1.0`).
