### PR TITLE
Support for LuaRocks with Visual Studio compiler.

### DIFF
--- a/luasec-0.6alpha-3.rockspec
+++ b/luasec-0.6alpha-3.rockspec
@@ -1,5 +1,5 @@
 package = "LuaSec"
-version = "0.6alpha-2"
+version = "0.6alpha-3"
 source = {
    url = "git://github.com/brunoos/luasec.git",
    tag = "luasec-0.6alpha"
@@ -91,8 +91,23 @@ build = {
                   "src/x509.c", "src/context.c", "src/ssl.c", 
                   "src/luasocket/buffer.c", "src/luasocket/io.c",
                   "src/luasocket/timeout.c", "src/luasocket/wsocket.c"
-               }
+               },
             }
+         },
+         patches = {
+            ["luarocks_vs_compiler.patch"] = [[
+--- a/src/ssl.c.orig
++++ b/src/ssl.c
+@@ -844,3 +844,8 @@ LSEC_API int luaopen_ssl_core(lua_State *L)
+
+   return 1;
+ }
++
++#if defined(_MSC_VER)
++/* Empty implementation to allow building with LuaRocks and MS compilers */
++LSEC_API int luaopen_ssl(lua_State *L) { return 0; }
++#endif
+]]
          }
       }
    }


### PR DESCRIPTION
Embeds a patch in the rockspec, adding a hack to allow luasec to compile when using LuaRocks and Visual Studio. This is needed until https://github.com/keplerproject/luarocks/issues/284 is fixed.

See #37 