### PR TITLE
Enables building with LuaRocks and MS compilers

### DIFF
--- a/luasec-0.6alpha-3.rockspec
+++ b/luasec-0.6alpha-3.rockspec
@@ -1,5 +1,5 @@
 package = "LuaSec"
-version = "0.6alpha-2"
+version = "0.6alpha-3"
 source = {
    url = "git://github.com/brunoos/luasec.git",
    tag = "luasec-0.6alpha"
@@ -93,6 +93,21 @@ build = {
                   "src/luasocket/timeout.c", "src/luasocket/wsocket.c"
                }
             }
+         },
+         patches = {
+            ["luarocks_vs_compiler.patch"] = [[
+--- a/src/ssl.c.orig
++++ b/src/ssl.c
+@@ -844,3 +844,8 @@ LSEC_API int luaopen_ssl_core(lua_State *L)
+
+   return 1;
+ }
++
++#if defined(_MSC_VER)
++/* Empty implementation to allow building with LuaRocks and MS compilers */
++LSEC_API int luaopen_ssl(lua_State *L) { return 0; }
++#endif
+]]
          }
       }
    }


### PR DESCRIPTION
A patch is added to the rockspec to fix an issue in the interaction between LuaRocks and Microsoft compilers.

LuaRocks build backend assumes the library being built will always export a symbol called "luaopen_<library name>". This is not the case with LuaSec so it fails to link.
The patch just adds an empty implementation of that, so it will properly link.

refs #37 