### PR TITLE
can not reset connection timeout

### DIFF
--- a/src/luasocket/timeout.c
+++ b/src/luasocket/timeout.c
@@ -171,6 +171,7 @@ int timeout_meth_settimeout(lua_State *L, p_timeout tm) {
             luaL_argcheck(L, 0, 3, "invalid timeout mode");
             break;
     }
+    tm->start = timeout_gettime();
     lua_pushnumber(L, 1);
     return 1;
 }


### PR DESCRIPTION
Currently implementation conn:settimeout() can take effect only once. recall of conn:settimeout() can not set a new timeout.
