### PR TITLE
Enable TLSv1.3 for stacks that support it

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -92,7 +92,7 @@ static int set_option_flag(const char *opt, unsigned long *flag)
  */
 static LSEC_SSL_METHOD* str2method(const char *method)
 {
-  if (!strcmp(method, "any"))     return SSLv23_method();
+  if (!strcmp(method, "any"))     return TLS_method();
   if (!strcmp(method, "sslv23"))  return SSLv23_method();  // deprecated
 #ifndef OPENSSL_NO_SSL3
   if (!strcmp(method, "sslv3"))   return SSLv3_method();

--- a/src/context.c
+++ b/src/context.c
@@ -102,6 +102,9 @@ static LSEC_SSL_METHOD* str2method(const char *method)
   if (!strcmp(method, "tlsv1_1")) return TLSv1_1_method();
   if (!strcmp(method, "tlsv1_2")) return TLSv1_2_method();
 #endif
+#ifdef TLS1_3_VERSION
+  if (!strcmp(method, "tlsv1_3")) return TLS_method();
+#endif
   return NULL;
 }
 
@@ -348,6 +351,15 @@ static int create(lua_State *L)
   ctx->L = L;
   luaL_getmetatable(L, "SSL:Context");
   lua_setmetatable(L, -2);
+
+#ifdef TLS1_3_VERSION
+  if (!strcmp(str_method, "any") || !strcmp(str_method, "tlsv1") || !strcmp(str_method, "tlsv1_3")) {
+    SSL_CTX_set_max_proto_version(ctx->context, TLS1_3_VERSION);
+  }
+  if (!strcmp(str_method, "tlsv1_3")) {
+    SSL_CTX_set_min_proto_version(ctx->context, TLS1_3_VERSION);
+  }
+#endif
 
   /* No session support */
   SSL_CTX_set_session_cache_mode(ctx->context, SSL_SESS_CACHE_OFF);

--- a/src/options.h
+++ b/src/options.h
@@ -106,6 +106,9 @@ static ssl_option_t ssl_options[] = {
 #if defined(SSL_OP_NO_TLSv1_2)
   {"no_tlsv1_2", SSL_OP_NO_TLSv1_2},
 #endif
+#if defined(SSL_OP_NO_TLSv1_3)
+  {"no_tlsv1_3", SSL_OP_NO_TLSv1_3},
+#endif
 #if defined(SSL_OP_PKCS1_CHECK_1)
   {"pkcs1_check_1", SSL_OP_PKCS1_CHECK_1},
 #endif


### PR DESCRIPTION
The focus of these changes is to utilize TLS 1.3 where available.

Using features such as "early data" is out of scope of this.