### PR TITLE
Fixes undefined lsec_load_curves and redefined luaL_newlib

### DIFF
--- a/luasec-0.6-1.rockspec
+++ b/luasec-0.6-1.rockspec
@@ -55,7 +55,7 @@ build = {
                   "ssl", "crypto"
                },
                sources = {
-                  "src/x509.c", "src/context.c", "src/ssl.c", 
+                  "src/x509.c", "src/context.c", "src/ec.c", "src/ssl.c", 
                   "src/luasocket/buffer.c", "src/luasocket/io.c",
                   "src/luasocket/timeout.c", "src/luasocket/usocket.c"
                }
@@ -88,7 +88,7 @@ build = {
                   "$(OPENSSL_INCDIR)", "src/", "src/luasocket"
                },
                sources = {
-                  "src/x509.c", "src/context.c", "src/ssl.c", 
+                  "src/x509.c", "src/context.c", "src/ec.c", "src/ssl.c", 
                   "src/luasocket/buffer.c", "src/luasocket/io.c",
                   "src/luasocket/timeout.c", "src/luasocket/wsocket.c"
                }

--- a/luasec-0.6-1.rockspec
+++ b/luasec-0.6-1.rockspec
@@ -55,7 +55,8 @@ build = {
                   "ssl", "crypto"
                },
                sources = {
-                  "src/x509.c", "src/context.c", "src/ec.c", "src/ssl.c", 
+                  "src/ec.c", "src/config.c",
+                  "src/x509.c", "src/context.c", "src/ssl.c",
                   "src/luasocket/buffer.c", "src/luasocket/io.c",
                   "src/luasocket/timeout.c", "src/luasocket/usocket.c"
                }
@@ -88,7 +89,8 @@ build = {
                   "$(OPENSSL_INCDIR)", "src/", "src/luasocket"
                },
                sources = {
-                  "src/x509.c", "src/context.c", "src/ec.c", "src/ssl.c", 
+                  "src/ec.c", "src/config.c",
+                  "src/x509.c", "src/context.c", "src/ssl.c", 
                   "src/luasocket/buffer.c", "src/luasocket/io.c",
                   "src/luasocket/timeout.c", "src/luasocket/wsocket.c"
                }

--- a/src/compat.h
+++ b/src/compat.h
@@ -16,7 +16,9 @@
 #if (LUA_VERSION_NUM == 501)
 #define setfuncs(L, R)    luaL_register(L, NULL, R)
 #define lua_rawlen(L, i)  lua_objlen(L, i)
+#ifndef luaL_newlib
 #define luaL_newlib(L, R) do { lua_newtable(L); luaL_register(L, NULL, R); } while(0)
+#endif
 #else
 #define setfuncs(L, R) luaL_setfuncs(L, R, 0)
 #endif


### PR DESCRIPTION
Avoids luaL_newlib redefinition and includes src/ec.c in the rockspec's sources. This fixes two compilation errors.