### PR TITLE
Use lowercase Windows header name

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #if defined(WIN32)
-#include <Winsock2.h>
+#include <winsock2.h>
 #endif
 
 #include <openssl/ssl.h>


### PR DESCRIPTION
This is necessary for cross-compilation of Windows binaries on non-Windows
platforms (and harmless for Windows).

Can this still make it to 0.7? :)