### PR TITLE
Update reference to Lua state prior to handshake

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -385,6 +385,7 @@ static int meth_handshake(lua_State *L)
   p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
   int err = handshake(ssl);
   p_context ctx = (p_context)SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl->ssl));
+  ctx->L = L;
   if (ctx->dh_param) {
     DH_free(ctx->dh_param);
     ctx->dh_param = NULL;


### PR DESCRIPTION
The Lua thread that creates the context is saved to be used for
accessing callback related data. However that thread may become garbage
and its memory could be overwritten with anything if the handshake
happens later, in a different thread.

Fixes #75