### PR TITLE
Disable TLSv1 protocol

### DIFF
--- a/src/https.lua
+++ b/src/https.lua
@@ -27,7 +27,7 @@ local _M = {
 -- TLS configuration
 local cfg = {
   protocol = "any",
-  options  = {"all", "no_sslv2", "no_sslv3"},
+  options  = {"all", "no_sslv2", "no_sslv3", "no_tlsv1"},
   verify   = "none",
 }
 


### PR DESCRIPTION
This is needed to fix "_received tlsv1 alert protocol version from_" errors with certain websites, since support for TLSv1 is being dropped.