### PR TITLE
Modernize certificate generation

### DIFF
--- a/samples/certs/all.sh
+++ b/samples/certs/all.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+./rootA.sh
+./rootB.sh
+./clientA.sh
+./clientB.sh
+./serverA.sh
+./serverB.sh

--- a/samples/certs/clientA.sh
+++ b/samples/certs/clientA.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-openssl req -newkey rsa:1024 -sha1 -keyout clientAkey.pem -out clientAreq.pem \
+openssl req -newkey rsa:2048 -sha256 -keyout clientAkey.pem -out clientAreq.pem \
   -nodes -config ./clientA.cnf -days 365 -batch
 
-openssl x509 -req -in clientAreq.pem -sha1 -extfile ./clientA.cnf \
+openssl x509 -req -in clientAreq.pem -sha256 -extfile ./clientA.cnf \
   -extensions usr_cert -CA rootA.pem -CAkey rootAkey.pem -CAcreateserial \
   -out clientAcert.pem -days 365
 

--- a/samples/certs/clientB.sh
+++ b/samples/certs/clientB.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-openssl req -newkey rsa:1024 -sha1 -keyout clientBkey.pem -out clientBreq.pem \
+openssl req -newkey rsa:2048 -sha256 -keyout clientBkey.pem -out clientBreq.pem \
   -nodes -config ./clientB.cnf -days 365 -batch
 
-openssl x509 -req -in clientBreq.pem -sha1 -extfile ./clientB.cnf \
+openssl x509 -req -in clientBreq.pem -sha256 -extfile ./clientB.cnf \
   -extensions usr_cert -CA rootB.pem -CAkey rootBkey.pem -CAcreateserial \
   -out clientBcert.pem -days 365
 

--- a/samples/certs/rootA.sh
+++ b/samples/certs/rootA.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-openssl req -newkey rsa:1024 -sha1 -keyout rootAkey.pem -out rootAreq.pem -nodes -config ./rootA.cnf -days 365 -batch
+openssl req -newkey rsa:2048 -sha256 -keyout rootAkey.pem -out rootAreq.pem -nodes -config ./rootA.cnf -days 365 -batch
 
-openssl x509 -req -in rootAreq.pem -sha1 -extfile ./rootA.cnf -extensions v3_ca -signkey rootAkey.pem -out rootA.pem -days 365
+openssl x509 -req -in rootAreq.pem -sha256 -extfile ./rootA.cnf -extensions v3_ca -signkey rootAkey.pem -out rootA.pem -days 365
 
 openssl x509 -subject -issuer -noout -in rootA.pem

--- a/samples/certs/rootB.sh
+++ b/samples/certs/rootB.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-openssl req -newkey rsa:1024 -sha1 -keyout rootBkey.pem -out rootBreq.pem -nodes -config ./rootB.cnf -days 365 -batch
+openssl req -newkey rsa:2048 -sha256 -keyout rootBkey.pem -out rootBreq.pem -nodes -config ./rootB.cnf -days 365 -batch
 
-openssl x509 -req -in rootBreq.pem -sha1 -extfile ./rootB.cnf -extensions v3_ca -signkey rootBkey.pem -out rootB.pem -days 365
+openssl x509 -req -in rootBreq.pem -sha256 -extfile ./rootB.cnf -extensions v3_ca -signkey rootBkey.pem -out rootB.pem -days 365
 
 openssl x509 -subject -issuer -noout -in rootB.pem

--- a/samples/certs/serverA.cnf
+++ b/samples/certs/serverA.cnf
@@ -118,7 +118,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 # so use this option with caution!
 string_mask = nombstr
 
-# req_extensions = v3_req # The extensions to add to a certificate request
+req_extensions = req_ext # The extensions to add to a certificate request
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)
@@ -198,7 +198,7 @@ authorityKeyIdentifier=keyid,issuer
 # subjectAltName=email:copy
 # An alternative to produce certificates that aren't
 # deprecated according to PKIX.
-# subjectAltName=email:move
+subjectAltName=DNS:foo.bar.example
 
 # Copy subject details
 # issuerAltName=issuer:copy

--- a/samples/certs/serverA.sh
+++ b/samples/certs/serverA.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-openssl req -newkey rsa:1024 -keyout serverAkey.pem -out serverAreq.pem \
+openssl req -newkey rsa:2048 -keyout serverAkey.pem -out serverAreq.pem \
    -config ./serverA.cnf -nodes -days 365 -batch
 
-openssl x509 -req -in serverAreq.pem -sha1 -extfile ./serverA.cnf \
+openssl x509 -req -in serverAreq.pem -sha256 -extfile ./serverA.cnf \
    -extensions usr_cert -CA rootA.pem -CAkey rootAkey.pem -CAcreateserial \
    -out serverAcert.pem -days 365
 

--- a/samples/certs/serverB.cnf
+++ b/samples/certs/serverB.cnf
@@ -195,7 +195,7 @@ authorityKeyIdentifier=keyid,issuer
 
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
-# subjectAltName=email:copy
+subjectAltName=DNS:fnord.bar.example
 # An alternative to produce certificates that aren't
 # deprecated according to PKIX.
 # subjectAltName=email:move

--- a/samples/certs/serverB.sh
+++ b/samples/certs/serverB.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-openssl req -newkey rsa:1024 -keyout serverBkey.pem -out serverBreq.pem \
+openssl req -newkey rsa:2048 -keyout serverBkey.pem -out serverBreq.pem \
    -config ./serverB.cnf -nodes -days 365 -batch
 
-openssl x509 -req -in serverBreq.pem -sha1 -extfile ./serverB.cnf \
+openssl x509 -req -in serverBreq.pem -sha256 -extfile ./serverB.cnf \
    -extensions usr_cert -CA rootB.pem -CAkey rootBkey.pem -CAcreateserial \
    -out serverBcert.pem -days 365
 


### PR DESCRIPTION
- Use 2048 bit keys (required for modern OpenSSL)
- Use SHA256 instead of SHA1 (required for modern OpenSSL)
- Add a SubjectAltName to be able to trigger certain edge-cases
- Add all.sh to conveniently re-generate certificates