### PR TITLE
Fix memory leak in meth_extensions

### DIFF
--- a/samples/loop/client.lua
+++ b/samples/loop/client.lua
@@ -23,6 +23,8 @@ while true do
    assert( peer:dohandshake() )
    --]]
 
+   peer:getpeercertificate():extensions()
+
    print(peer:receive("*l"))
    peer:close()
 end

--- a/src/x509.c
+++ b/src/x509.c
@@ -372,6 +372,7 @@ int meth_extensions(lua_State* L)
         break;
       }
     }
+    sk_GENERAL_NAME_free(values);
     lua_pop(L, 1); /* ret[oid] */
     i++;           /* Next extension */
   }


### PR DESCRIPTION
``X509V3_EXT_d2i`` allocates a thing which needs to be freed. I added the free call.

To reproduce, you’ll need the patches from this branch as well as #124, because it only happens when the certificate has a Subject Alternative Name extension (which is probably why it wasn’t caught in the normal loop testing yet).

You can reproduce the memory leak  by applying only #124 and 0775d57 and then run the loop client under ``valgrind --leak-check=full lua ./client.lua`` (it takes a while to start up).

Let it run for a few iterations and then abort it with Ctrl+C. Valgrind will show a leak like this:

```
==5623== 720 (192 direct, 528 indirect) bytes in 6 blocks are definitely lost in loss record 8 of 10
==5623==    at 0x48357BF: malloc (vg_replace_malloc.c:299)
==5623==    by 0x5710CE8: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x57719AE: OPENSSL_sk_new_reserve (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x5636264: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x5636488: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x563566D: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x563658C: ASN1_item_ex_d2i (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x563660A: ASN1_item_d2i (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x579D004: X509V3_EXT_d2i (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==5623==    by 0x484B1BD: ???
==5623==    by 0x112F94: ??? (in /usr/bin/lua5.2)
==5623==    by 0x11D724: ??? (in /usr/bin/lua5.2)
```

After applying 81c3886, the leak is gone.