### PR TITLE
Expose tcp() for use by LuaSocket

### DIFF
--- a/src/https.lua
+++ b/src/https.lua
@@ -141,5 +141,6 @@ end
 --
 
 _M.request = request
+_M.tcp = tcp
 
 return _M


### PR DESCRIPTION
Exposing the `tcp()` function would allow LuaSocket HTTPS redirects to succeed transparently without the caller having to provide a separate socket creation function. Also allows normal HTTP or HTTPS requests via the same call. See also [diegonehab/luasocket:#268](https://github.com/diegonehab/luasocket/pull/268).