### PR TITLE
Enable multiple SSL certificates

### DIFF
--- a/samples/multicert/client.lua
+++ b/samples/multicert/client.lua
@@ -1,0 +1,33 @@
+--
+-- Public domain
+--
+local socket = require("socket")
+local ssl    = require("ssl")
+
+local params = {
+   mode = "client",
+   protocol = "tlsv1_2",
+   key = "../certs/clientAkey.pem",
+   certificate = "../certs/clientA.pem",
+   cafile = "../certs/rootA.pem",
+   verify = {"peer", "fail_if_no_peer_cert"},
+   options = "all",
+   --
+   curve = "secp384r1",
+}
+
+--------------------------------------------------------------------------------
+local peer = socket.tcp()
+peer:connect("127.0.0.1", 8888)
+
+peer = assert( ssl.wrap(peer, params) )
+assert(peer:dohandshake())
+
+print("--- INFO  ---")
+local info = peer:info()
+for k, v in pairs(info) do
+  print(k, v)
+end
+print("---")
+
+peer:close()

--- a/samples/multicert/server.lua
+++ b/samples/multicert/server.lua
@@ -1,0 +1,48 @@
+--
+-- Public domain
+--
+local socket = require("socket")
+local ssl    = require("ssl")
+
+local params = {
+   mode = "server",
+   protocol = "any",
+   certificates = {
+      {
+         key = "../certs/serverAkey.pem",
+         certificate = "../certs/serverA.pem"
+      },
+      {
+         key = "../certs/serverBkey.pem",
+         certificate = "../certs/serverB.pem"
+      }
+   },
+   cafile = "../certs/rootA.pem",
+   verify = {"peer", "fail_if_no_peer_cert"},
+   options = "all",
+   --
+   curve = "secp384r1",
+}
+
+------------------------------------------------------------------------------
+local ctx = assert(ssl.newcontext(params))
+
+local server = socket.tcp()
+server:setoption('reuseaddr', true)
+assert( server:bind("127.0.0.1", 8888) )
+server:listen()
+
+local peer = server:accept()
+
+peer = assert( ssl.wrap(peer, ctx) )
+assert( peer:dohandshake() )
+
+print("--- INFO ---")
+local info = peer:info()
+for k, v in pairs(info) do
+  print(k, v)
+end
+print("---")
+
+peer:close()
+server:close()

--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -74,25 +74,39 @@ local function newcontext(cfg)
    -- Mode
    succ, msg = context.setmode(ctx, cfg.mode)
    if not succ then return nil, msg end
-   -- Load the key
-   if cfg.key then
-      if cfg.password and
-         type(cfg.password) ~= "function" and
-         type(cfg.password) ~= "string"
-      then
-         return nil, "invalid password type"
+   -- Wrap singular certificate, key, etc in tables if necessary
+   for _, prop in pairs({ "key", "certificate", "password" }) do
+      if not cfg[prop .. "s"] then
+         if cfg[prop] then
+            cfg[prop .. "s"] = { cfg[prop] }
+         else
+            cfg[prop .. "s"] = {}
+         end
       end
-      succ, msg = context.loadkey(ctx, cfg.key, cfg.password)
-      if not succ then return nil, msg end
    end
-   -- Load the certificate
-   if cfg.certificate then
-     succ, msg = context.loadcert(ctx, cfg.certificate)
-     if not succ then return nil, msg end
-     if cfg.key and context.checkkey then
-       succ = context.checkkey(ctx)
-       if not succ then return nil, "private key does not match public key" end
-     end
+   for i, certificate in pairs(cfg.certificates) do
+      local password = cfg.passwords[i]
+      local key = cfg.keys[i]
+      -- Load the key
+      if key then
+         if password and
+            type(password) ~= "function" and
+            type(password) ~= "string"
+         then
+            return nil, "invalid password type"
+         end
+         succ, msg = context.loadkey(ctx, key, password)
+         if not succ then return nil, msg end
+      end
+      -- Load the certificate(s)
+      if certificate then
+        succ, msg = context.loadcert(ctx, certificate)
+        if not succ then return nil, msg end
+        if key and context.checkkey then
+          succ = context.checkkey(ctx)
+          if not succ then return nil, "private key does not match public key" end
+        end
+      end
    end
    -- Load the CA certificates
    if cfg.cafile or cfg.capath then


### PR DESCRIPTION
This allows a context to be set up with multiple certificates. This is done similarly to using a single certificate in existing branches, except that the property names in the `cfg` table are pluralized and are passed as tables with matching keys rather than as three individual strings.

Backwards-compatibility is achieved by wrapping the individual strings in tables if they are passed in that manner.

This fixes #27