### PR TITLE
Update x509.c

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -11,6 +11,7 @@
 
 #if defined(WIN32)
 #include <ws2tcpip.h>
+#include <wspiapi.h>
 #include <windows.h>
 #else
 #include <sys/types.h>


### PR DESCRIPTION
The included file wspiapi.h solves a problem on older versions of windows that do not have inet_ntop and getnameinfo functions in ws2_32.dll.  The fix is documented on this page: https://docs.microsoft.com/en-us/windows/desktop/api/ws2tcpip/nf-ws2tcpip-getnameinfo.

The paragraph titled "Support for getnameinfo on older versions of Windows" explains it all.