### PR TITLE
Fix general_name leak in cert:extensions()

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -371,6 +371,7 @@ int meth_extensions(lua_State* L)
         /* not supported */
         break;
       }
+      GENERAL_NAME_free(general_name);
     }
     sk_GENERAL_NAME_free(values);
     lua_pop(L, 1); /* ret[oid] */


### PR DESCRIPTION
Similar to #125.

To reproduce:

```lua
cert = require"ssl".loadcertificate(io.open("example.crt"):read("*a"))
cert:extensions()
```

Thanks to @zeen for identifying and @horazont for providing test
environment.

