### PR TITLE
SOCKET_INVALID pushed as integer, not as number

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -941,7 +941,7 @@ LSEC_API int luaopen_ssl_core(lua_State *L)
   luaL_newlib(L, funcs);
 
   lua_pushstring(L, "SOCKET_INVALID");
-  lua_pushnumber(L, SOCKET_INVALID);
+  lua_pushinteger(L, SOCKET_INVALID);
   lua_rawset(L, -3);
 
   return 1;


### PR DESCRIPTION
winsock define INVALID_SOCKET as (UINT_PTR)(~0)
in win64 it is 0xffffffffffffffff
if pushed by lua_pushnumber, then ssl.core.SOCKET_INVALID is 1.84467440737096E19

tested in win32/64, linux32/64 lua5.1 and lua5.3