### PR TITLE
Handle SSL_send SYSCALL error without errno

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -182,6 +182,10 @@ static int ssl_send(void *ctx, const char *data, size_t count, size_t *sent,
         ssl->error = SSL_ERROR_SSL;
         return LSEC_IO_SSL;
       }
+      /* Return failure when SSL reports syscall error
+       * but errno is not set to break send operation. */
+      if (errno == 0)
+        return LSEC_IO_SSL;
       if (err == 0)
         return IO_CLOSED;
       return lsec_socket_error();


### PR DESCRIPTION
Either intentionaly or due to bug in openssl in some marginal
cases SSL_send reports SYSCALL error whilst errno is set to 0.
This either could mean that SSL_send did not made any system
call or errno were prematurely reset with consequent syscalls.
And in consequence sendraw() is not propagated with correct
errno ends up in infinite loop trying to send same data.

Such behaviour was usually observed after third consequential
failed SSL send attempt which application was not aware of.
First send failed with syscall errno 32 (Broken pipe) second
one with SSL error 0x1409e10f (bad length) and lastly next
send attemt results with SYSCALL error and errno 0.

Tested using:
* OpenSSL v1.1.1
* musl v1.1.20 (c50985d5c8e316c5c464f352e79eeebfed1121a9)
* Linux 4.4.60+yocto armv7l