### PR TITLE
Support passing DANE flags

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -77,7 +77,14 @@ LSEC_API int luaopen_ssl_config(lua_State *L)
 #ifdef LSEC_ENABLE_DANE
   // DANE
   lua_pushstring(L, "dane");
+#ifdef DANE_FLAG_NO_DANE_EE_NAMECHECKS
+  lua_createtable(L, 0, 1);
+  lua_pushstring(L, "no_ee_namechecks");
   lua_pushboolean(L, 1);
+  lua_rawset(L, -3);
+#else
+  lua_pushboolean(L, 1);
+#endif
   lua_rawset(L, -3);
 #endif
 

--- a/src/context.c
+++ b/src/context.c
@@ -17,6 +17,7 @@
 #include <openssl/err.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <openssl/x509_vfy.h>
 #include <openssl/dh.h>
 
 #include <lua.h>
@@ -711,11 +712,31 @@ static int set_alpn_cb(lua_State *L)
 /*
  * DANE
  */
+static int dane_options[] = {
+  /* TODO move into options.c
+   * however this symbol is not from openssl/ssl.h but rather from
+   * openssl/x509_vfy.h
+   * */
+#ifdef DANE_FLAG_NO_DANE_EE_NAMECHECKS
+  DANE_FLAG_NO_DANE_EE_NAMECHECKS,
+#endif
+  0
+};
+static const char *dane_option_names[] = {
+#ifdef DANE_FLAG_NO_DANE_EE_NAMECHECKS
+  "no_ee_namechecks",
+#endif
+  NULL
+};
+
 static int set_dane(lua_State *L)
 {
-  int ret;
+  int ret, i;
   SSL_CTX *ctx = lsec_checkcontext(L, 1);
   ret = SSL_CTX_dane_enable(ctx);
+  for (i = 2; ret > 0 && i <= lua_gettop(L); i++) {
+    ret = SSL_CTX_dane_set_flags(ctx, dane_options[luaL_checkoption(L, i, NULL, dane_option_names)]);
+  }
   lua_pushboolean(L, (ret > 0));
   return 1;
 }

--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -202,7 +202,11 @@ local function newcontext(cfg)
    end
 
    if config.capabilities.dane and cfg.dane then
-      context.setdane(ctx)
+      if type(cfg.dane) == "table" then
+         context.setdane(ctx, unpack(cfg.dane))
+      else
+         context.setdane(ctx)
+      end
    end
 
    return ctx


### PR DESCRIPTION
The only flag at the moment is one that disables name checks, which is
needed for certain protocols such as XMPP.

API comments welcome.

Sorry I missed this in #122 

```lua
local conn = ssl.wrap(socket.connect(host, port), {
  mode = "client",
  ... -- other settings etc
  dane = { "no_ee_namechecks" }
})
conn:setdane(host); -- still need the host, but its value is ignored
conn:settlsa(3, 1, 1, hex"deadbeef..."))
conn:dohandshake()
```