### PR TITLE
Add key material export method

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -672,6 +672,42 @@ static int meth_getpeerfinished(lua_State *L)
 }
 
 /**
+ */
+static int meth_exportkeyingmaterial(lua_State *L)
+{
+	p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
+
+	if(ssl->state != LSEC_STATE_CONNECTED) {
+		lua_pushnil(L);
+		lua_pushstring(L, "closed");
+		return 0;
+	}
+
+	size_t llen = 0;
+	const char *label = luaL_checklstring(L, 2, &llen);
+	int olen = luaL_checkinteger(L, 3);
+	size_t contextlen = 0;
+	const unsigned char *context = NULL;
+
+	if(!lua_isnoneornil(L, 4)) {
+		const unsigned char *context = (unsigned char *)luaL_checklstring(L, 4, &contextlen);
+	}
+
+	/* temporary buffer memory-managed by Lua itself */
+	unsigned char *out = lua_newuserdata(L, olen);
+
+	if(SSL_export_keying_material(ssl->ssl, out, olen, label, llen, context, contextlen, context != NULL) != 1) {
+		lua_pushnil(L);
+		/* Could not find whether OpenSSL keeps any details anywhere */
+		lua_pushstring(L, "error exporting keying material");
+		return 2;
+	}
+
+	lua_pushlstring(L, (char *)out, olen);
+	return 1;
+}
+
+/**
  * Object information -- tostring metamethod
  */
 static int meth_tostring(lua_State *L)
@@ -876,6 +912,7 @@ static luaL_Reg methods[] = {
   {"getpeerchain",        meth_getpeerchain},
   {"getpeerverification", meth_getpeerverification},
   {"getpeerfinished",     meth_getpeerfinished},
+  {"exportkeyingmaterial",meth_exportkeyingmaterial},
   {"getsniname",          meth_getsniname},
   {"getstats",            meth_getstats},
   {"setstats",            meth_setstats},


### PR DESCRIPTION
Binds [`SSL_export_keying_material()`](https://www.openssl.org/docs/manmaster/man3/SSL_export_keying_material.html) which is used for things like [SASL channel binding](https://datatracker.ietf.org/doc/draft-ietf-kitten-tls-channel-bindings-for-tls13/).