### PR TITLE
backguard compat for openssl on providers, like LTS linuxes

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -655,6 +655,7 @@ static int meth_set_encode(lua_State* L)
   return 1;
 }
 
+#if (OPENSSL_VERSION_NUMBER >= 0x1010000fL)
 /**
  * Get signature name.
  */
@@ -669,6 +670,7 @@ static int meth_get_signature_name(lua_State* L)
     lua_pushstring(L, name);
   return 1;
 }
+#endif
 
 /*---------------------------------------------------------------------------*/
 
@@ -698,7 +700,9 @@ static luaL_Reg methods[] = {
   {"digest",     meth_digest},
   {"setencode",  meth_set_encode},
   {"extensions", meth_extensions},
+#if (OPENSSL_VERSION_NUMBER >= 0x1010000fL)
   {"getsignaturename", meth_get_signature_name},
+#endif
   {"issuer",     meth_issuer},
   {"notbefore",  meth_notbefore},
   {"notafter",   meth_notafter},


### PR DESCRIPTION
* The commit https://github.com/brunoos/luasec/commit/de393417b7c7566caf1e0a0ad54132942ac4f049 introduces high dependency due raices requirement to openssl 1.1.0l+
* The X509_REQ_get0_signature(), X509_REQ_get_signature_nid(), X509_CRL_get0_signature() and X509_CRL_get_signature_nid() were added in OpenSSL 1.1.0.
* This patch makes luasec runs on all kind of embebed systems that cannot be upgraded due vendors limitations