### PR TITLE
usocket.c: place EAI_OVERFLOW inside macro, unbreak build on <10.7

### DIFF
--- a/src/luasocket/usocket.c
+++ b/src/luasocket/usocket.c
@@ -426,7 +426,9 @@ const char *socket_gaistrerror(int err) {
         case EAI_MEMORY: return "memory allocation failure";
         case EAI_NONAME: 
             return "host or service not provided, or not known";
+#ifdef EAI_OVERFLOW
         case EAI_OVERFLOW: return "argument buffer overflow";
+#endif
 #ifdef EAI_PROTOCOL
         case EAI_PROTOCOL: return "resolved protocol is unknown";
 #endif


### PR DESCRIPTION
Some systems have no `EAI_OVERFLOW`, in particular macOS <= 10.5, as well as early versions of 10.6.
Protect it with the macro, in the same way as it is done below for `EAI_PROTOCOL`.