### PR TITLE
Expand workaround for zero errno to OpenSSL 3.0.x

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -48,8 +48,8 @@
 
 //------------------------------------------------------------------------------
 
-#if !defined(LIBRESSL_VERSION_NUMBER) && ((OPENSSL_VERSION_NUMBER & 0xFFFFF000L) == 0x10101000L)
-#define LSEC_OPENSSL_1_1_1
+#if !defined(LIBRESSL_VERSION_NUMBER) && ((OPENSSL_VERSION_NUMBER & 0xFFFFF000L) == 0x10101000L || (OPENSSL_VERSION_NUMBER & 0xFFFFF000L) == 0x30000000L)
+#define LSEC_OPENSSL_ERRNO_BUG
 #endif
 
 //------------------------------------------------------------------------------

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -47,8 +47,8 @@ static int lsec_socket_error()
 #if defined(WIN32)
   return WSAGetLastError();
 #else
-#if defined(LSEC_OPENSSL_1_1_1)
-  // Bug in OpenSSL 1.1.1
+#if defined(LSEC_OPENSSL_ERRNO_BUG)
+  // Bug in OpenSSL
   if (errno == 0)
     return LSEC_IO_SSL;
 #endif


### PR DESCRIPTION
Encountered the bug in #172 after upgrading to OpenSSL 3.0.9, so it appears to still be present.

Occurs when writing to a connection that has been closed by the remote.