### PR TITLE
Add TCP socket method passthroughs to SSL objects

### DIFF
--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -253,6 +253,11 @@ local function wrap(sock, cfg)
    local s, msg = core.create(ctx)
    if s then
       core.setfd(s, sock:getfd())
+      -- Add TCP socket method passthroughs
+      s.getpeername = function() return sock:getpeername() end
+      s.getsockname = function() return sock:getsockname() end
+      s.getoption = function(self, ...) return sock:getoption(...) end
+      s.setoption = function(self, ...) return sock:setoption(...) end
       sock:setfd(core.SOCKET_INVALID)
       registry[s] = ctx
       return s


### PR DESCRIPTION
Addresses #170

Adds the following tcp methods to SSL objects by delegating to the underlying TCP socket before invalidation. This restores access to connection metadata after SSL wrapping. These should be non-blocking:
- getpeername
- getsockname
- getoption
- setoption 

I am hoping to pass these on to cosock next and ultimately the SmartThings Edge platform.