### PR TITLE
feat(sni): expose checkhost to verify the sni name

### DIFF
--- a/samples/checkhost/client.lua
+++ b/samples/checkhost/client.lua
@@ -1,0 +1,78 @@
+--
+-- Public domain
+--
+-- Demonstrates (and doubles as a test for) X509 certificate:checkhost(),
+-- which wraps OpenSSL's X509_check_host() to verify that a certificate is
+-- valid for a given hostname (checking subjectAltName dNSName entries,
+-- falling back to the subject CommonName).
+--
+-- ../certs/serverA.cnf sets: subjectAltName=DNS:foo.bar.example
+--
+local socket = require("socket")
+local ssl    = require("ssl")
+
+local params = {
+   mode = "client",
+   protocol = "tlsv1_2",
+   cafile = "../certs/rootA.pem",
+   verify = "peer",
+   options = "all",
+}
+
+local peer = socket.tcp()
+peer:connect("127.0.0.1", 8888)
+
+-- [[ SSL wrapper
+peer = assert( ssl.wrap(peer, params) )
+assert( peer:dohandshake() )
+--]]
+
+local cert = assert(peer:getpeercertificate())
+
+local cases = {
+   { host = "foo.bar.example", expect = true  }, -- matches subjectAltName
+   { host = "evil.example",    expect = false }, -- no match
+}
+
+local failures = 0
+
+for _, case in ipairs(cases) do
+   local ok = cert:checkhost(case.host)
+   local pass = (ok == case.expect)
+   if not pass then failures = failures + 1 end
+   print(string.format("checkhost(%-20s) = %-5s (expected %-5s) %s",
+      case.host, tostring(ok), tostring(case.expect), pass and "OK" or "FAIL"))
+end
+
+-- Named X509_CHECK_FLAG_* options can be passed after the hostname.
+do
+   local ok = cert:checkhost("foo.bar.example", "no_wildcards", "single_label_subdomains")
+   local pass = (ok == true)
+   if not pass then failures = failures + 1 end
+   print(string.format("checkhost(host, flags...)        = %-5s (expected true ) %s",
+      tostring(ok), pass and "OK" or "FAIL"))
+end
+
+-- An unknown flag name must be rejected, not silently ignored.
+do
+   local ok, err = cert:checkhost("foo.bar.example", "bogus_flag")
+   local pass = (ok == nil and err ~= nil)
+   if not pass then failures = failures + 1 end
+   print(string.format("checkhost(host, \"bogus_flag\")     = %-5s err=%-30s %s",
+      tostring(ok), tostring(err), pass and "OK" or "FAIL"))
+end
+
+-- An embedded NUL makes the name malformed: checkhost() must report an
+-- error instead of silently matching or not matching.
+do
+   local ok, err = cert:checkhost("foo.bar.example\0evil.example")
+   local pass = (ok == nil and err ~= nil)
+   if not pass then failures = failures + 1 end
+   print(string.format("checkhost(embedded NUL)          = %-5s err=%-24s %s",
+      tostring(ok), tostring(err), pass and "OK" or "FAIL"))
+end
+
+print(peer:receive("*l"))
+peer:close()
+
+os.exit(failures == 0 and 0 or 1)

--- a/samples/checkhost/server.lua
+++ b/samples/checkhost/server.lua
@@ -1,0 +1,34 @@
+--
+-- Public domain
+--
+local socket = require("socket")
+local ssl    = require("ssl")
+
+local params = {
+   mode = "server",
+   protocol = "any",
+   key = "../certs/serverAkey.pem",
+   certificate = "../certs/serverA.pem",
+   cafile = "../certs/rootA.pem",
+   verify = "none",
+   options = "all",
+}
+
+-- [[ SSL context
+local ctx = assert(ssl.newcontext(params))
+--]]
+
+local server = socket.tcp()
+server:setoption('reuseaddr', true)
+assert( server:bind("127.0.0.1", 8888) )
+server:listen()
+
+local peer = server:accept()
+
+-- [[ SSL wrapper
+peer = assert( ssl.wrap(peer, ctx) )
+assert( peer:dohandshake() )
+--]]
+
+peer:send("checkhost test\n")
+peer:close()

--- a/samples/sethost/client.lua
+++ b/samples/sethost/client.lua
@@ -1,0 +1,92 @@
+--
+-- Public domain
+--
+-- Demonstrates (and doubles as a test for) automatic, connection-level
+-- hostname verification via cfg.host / conn:sethost() / conn:sethostflags(),
+-- as opposed to the manual, post-handshake x509:checkhost() (see
+-- ../checkhost/client.lua). Because the check runs as part of the
+-- connection's own certificate verification, a mismatch fails the handshake
+-- itself -- no separate application-side call is needed.
+--
+-- ../certs/serverA.cnf sets: subjectAltName=DNS:foo.bar.example
+--
+local socket = require("socket")
+local ssl    = require("ssl")
+
+local failures = 0
+
+local function connect(cfg)
+   local sock = socket.tcp()
+   assert(sock:connect("127.0.0.1", 8889))
+   return ssl.wrap(sock, cfg)
+end
+
+local base = {
+   mode = "client",
+   protocol = "tlsv1_2",
+   cafile = "../certs/rootA.pem",
+   verify = "peer",
+   options = "all",
+}
+
+-- Matching hostname: handshake must succeed.
+do
+   local cfg = {}
+   for k, v in pairs(base) do cfg[k] = v end
+   cfg.host = "foo.bar.example"
+
+   local peer = assert(connect(cfg))
+   local ok = peer:dohandshake()
+   if not ok then failures = failures + 1 end
+   print(string.format("sethost(matching host)   dohandshake = %-5s (expected true ) %s",
+      tostring(ok), ok and "OK" or "FAIL"))
+   if ok then print(peer:receive("*l")) end
+   peer:close()
+end
+
+-- Mismatched hostname: handshake must fail, with no manual checkhost() call.
+do
+   local cfg = {}
+   for k, v in pairs(base) do cfg[k] = v end
+   cfg.host = "evil.example"
+
+   local peer = assert(connect(cfg))
+   local ok, err = peer:dohandshake()
+   local pass = (ok == nil or ok == false)
+   if not pass then failures = failures + 1 end
+   print(string.format("sethost(mismatched host) dohandshake = %-5s err=%-30s (expected false) %s",
+      tostring(ok), tostring(err), pass and "OK" or "FAIL"))
+   peer:close()
+end
+
+-- Invalid hostflags option must be rejected by wrap() itself -- no network
+-- round-trip required, so no socket connection is made for this case.
+do
+   local cfg = {}
+   for k, v in pairs(base) do cfg[k] = v end
+   cfg.host = "foo.bar.example"
+   cfg.hostflags = "bogus_flag"
+
+   local ok, err = ssl.wrap(socket.tcp(), cfg)
+   local pass = (ok == nil and err ~= nil)
+   if not pass then failures = failures + 1 end
+   print(string.format("sethostflags(\"bogus_flag\") = %-5s err=%-30s (expected nil  ) %s",
+      tostring(ok), tostring(err), pass and "OK" or "FAIL"))
+end
+
+-- cfg.host combined with cfg.dane must be rejected: DANE clients are meant
+-- to set the hostname via conn:setdane(host) instead (see SSL_set1_host(3)).
+do
+   local cfg = {}
+   for k, v in pairs(base) do cfg[k] = v end
+   cfg.host = "foo.bar.example"
+   cfg.dane = true
+
+   local ok, err = ssl.wrap(socket.tcp(), cfg)
+   local pass = (ok == nil and err ~= nil)
+   if not pass then failures = failures + 1 end
+   print(string.format("host+dane conflict         = %-5s err=%-30s (expected nil  ) %s",
+      tostring(ok), tostring(err), pass and "OK" or "FAIL"))
+end
+
+os.exit(failures == 0 and 0 or 1)

--- a/samples/sethost/server.lua
+++ b/samples/sethost/server.lua
@@ -1,0 +1,34 @@
+--
+-- Public domain
+--
+local socket = require("socket")
+local ssl    = require("ssl")
+
+local params = {
+   mode = "server",
+   protocol = "any",
+   key = "../certs/serverAkey.pem",
+   certificate = "../certs/serverA.pem",
+   cafile = "../certs/rootA.pem",
+   verify = "none",
+   options = "all",
+}
+
+local ctx = assert(ssl.newcontext(params))
+
+local server = socket.tcp()
+server:setoption('reuseaddr', true)
+assert( server:bind("127.0.0.1", 8889) )
+server:listen()
+
+-- Two connections: one where the client's expected hostname matches the
+-- certificate, one where it doesn't. The server itself is oblivious to the
+-- hostname check -- that happens entirely on the client side.
+for _ = 1, 2 do
+   local peer = server:accept()
+   peer = ssl.wrap(peer, ctx)
+   if peer:dohandshake() then
+      pcall(peer.send, peer, "sethost test\n")
+   end
+   peer:close()
+end

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -983,6 +983,66 @@ static int meth_tlsa(lua_State *L)
 }
 #endif
 
+/**
+ * Set the expected peer hostname for automatic verification (RFC 6125).
+ *
+ * Unlike x509:checkhost(), this wraps SSL_set1_host() (X509_VERIFY_PARAM_set1_host()),
+ * so the hostname check happens as part of the connection's own certificate
+ * verification during the handshake, and is correctly suppressed by OpenSSL
+ * when DANE-EE applies. Must be called before dohandshake(). Do not combine
+ * with DANE (SSL_set1_host()'s own docs say DANE clients should leave the
+ * primary reference identifier to setdane() instead).
+ */
+static int meth_sethost(lua_State *L)
+{
+  int ret;
+  size_t len;
+  p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
+  const char *name = luaL_checklstring(L, 2, &len);
+
+  if (len != strlen(name)) {
+    lua_pushnil(L);
+    lua_pushliteral(L, "malformed hostname (embedded NUL)");
+    return 2;
+  }
+
+  ERR_clear_error();
+  ret = SSL_set1_host(ssl->ssl, name);
+  if (ret <= 0) {
+    const char *reason = ERR_reason_error_string(ERR_get_error());
+    lua_pushnil(L);
+    lua_pushfstring(L, "error setting hostname (%s)", reason ? reason : "internal error");
+    return 2;
+  }
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+/**
+ * Set the X509_check_host() flags used by the automatic hostname check
+ * configured via sethost(). Accepts the same option names as x509:checkhost().
+ */
+static int meth_sethostflags(lua_State *L)
+{
+  int i, max;
+  const char *opt;
+  unsigned int flags = 0;
+  p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
+
+  max = lua_gettop(L);
+  for (i = 2; i <= max; i++) {
+    opt = luaL_checkstring(L, i);
+    if (!lsec_set_checkhost_flag(opt, &flags)) {
+      lua_pushnil(L);
+      lua_pushfstring(L, "invalid checkhost option (%s)", opt);
+      return 2;
+    }
+  }
+  SSL_set_hostflags(ssl->ssl, flags);
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
 /*---------------------------------------------------------------------------*/
 
 /**
@@ -1008,6 +1068,8 @@ static luaL_Reg methods[] = {
   {"receive",             meth_receive},
   {"send",                meth_send},
   {"settimeout",          meth_settimeout},
+  {"sethost",             meth_sethost},
+  {"sethostflags",        meth_sethostflags},
   {"sni",                 meth_sni},
   {"want",                meth_want},
 #if defined(LSEC_ENABLE_DANE)

--- a/src/ssl.lua
+++ b/src/ssl.lua
@@ -210,7 +210,7 @@ local function newcontext(cfg)
       end
       context.setdhparam(ctx, cfg.dhparam)
    end
-   
+
    -- Set elliptic curves
    if (not config.algorithms.ec) and (cfg.curve or cfg.curveslist) then
      return false, "elliptic curves not supported"
@@ -313,8 +313,13 @@ end
 --
 --
 local function wrap(sock, cfg)
-   local ctx, msg
+   local ctx, msg, host, hostflags
    if type(cfg) == "table" then
+      host, hostflags = cfg.host, cfg.hostflags
+      if host and cfg.dane then
+         return nil, "cfg.host must not be combined with cfg.dane; " ..
+            "DANE clients must set the peer hostname via conn:setdane(host) instead"
+      end
       ctx, msg = newcontext(cfg)
       if not ctx then return nil, msg end
    else
@@ -325,9 +330,16 @@ local function wrap(sock, cfg)
       core.setfd(s, sock:getfd())
       sock:setfd(core.SOCKET_INVALID)
       registry[s] = ctx
+      if host then
+         local succ, err = optexec(s.sethostflags, hostflags, s)
+         if succ then
+            succ, err = s:sethost(host)
+         end
+         if not succ then return nil, err end
+      end
       return s
    end
-   return nil, msg 
+   return nil, msg
 end
 
 --

--- a/src/x509.c
+++ b/src/x509.c
@@ -481,6 +481,74 @@ static int meth_digest(lua_State* L)
 }
 
 /**
+ * Prepare the X509_check_host() flags.
+ */
+static int set_checkhost_flag(const char *opt, unsigned int *flag)
+{
+  if (!strcmp(opt, "always_check_subject")) {
+    *flag |= X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT;
+  } else if (!strcmp(opt, "no_wildcards")) {
+    *flag |= X509_CHECK_FLAG_NO_WILDCARDS;
+  } else if (!strcmp(opt, "no_partial_wildcards")) {
+    *flag |= X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
+  } else if (!strcmp(opt, "multi_label_wildcards")) {
+    *flag |= X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS;
+  } else if (!strcmp(opt, "single_label_subdomains")) {
+    *flag |= X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS;
+#if defined(X509_CHECK_FLAG_NEVER_CHECK_SUBJECT)
+  } else if (!strcmp(opt, "never_check_subject")) {
+    *flag |= X509_CHECK_FLAG_NEVER_CHECK_SUBJECT;
+#endif
+  } else {
+    return 0;
+  }
+  return 1;
+}
+
+/**
+ * Check if the certificate matches the given hostname (RFC 6125).
+ *
+ * This is a manual, standalone check (wraps X509_check_host() directly) and
+ * is not aware of DANE. On a DANE-EE connection a certificate may legitimately
+ * not match the hostname, so this function must not be used as a substitute
+ * for the connection's own peer verification in that case. OpenSSL recommends
+ * X509_VERIFY_PARAM_set1_host() (via SSL_set1_host()) for that purpose, since
+ * it cooperates with DANE's internal suppression of the hostname check; this
+ * function is for one-off checks against an arbitrary certificate instead.
+ */
+static int meth_checkhost(lua_State* L)
+{
+  int i, max;
+  size_t len;
+  int ret;
+  const char *opt;
+  unsigned int flags = 0;
+  X509 *cert = lsec_checkx509(L, 1);
+  const char *name = luaL_checklstring(L, 2, &len);
+
+  max = lua_gettop(L);
+  for (i = 3; i <= max; i++) {
+    opt = luaL_checkstring(L, i);
+    if (!set_checkhost_flag(opt, &flags)) {
+      lua_pushnil(L);
+      lua_pushfstring(L, "invalid checkhost option (%s)", opt);
+      return 2;
+    }
+  }
+
+  ret = X509_check_host(cert, name, len, flags, NULL);
+  if (ret < 0) {
+    const char *reason = ERR_reason_error_string(ERR_get_error());
+    lua_pushnil(L);
+    lua_pushfstring(L, "error checking hostname (%s)",
+      reason ? reason : (ret == -2 ? "malformed name" : "internal error"));
+    return 2;
+  }
+  lua_pushboolean(L, ret);
+  return 1;
+}
+
+/**
  * Check if the certificate is valid in a given time.
  */
 static int meth_valid_at(lua_State* L)
@@ -697,6 +765,7 @@ static int load_cert(lua_State* L)
  * Certificate methods.
  */
 static luaL_Reg methods[] = {
+  {"checkhost",  meth_checkhost},
   {"digest",     meth_digest},
   {"setencode",  meth_set_encode},
   {"extensions", meth_extensions},

--- a/src/x509.c
+++ b/src/x509.c
@@ -483,7 +483,7 @@ static int meth_digest(lua_State* L)
 /**
  * Prepare the X509_check_host() flags.
  */
-static int set_checkhost_flag(const char *opt, unsigned int *flag)
+int lsec_set_checkhost_flag(const char *opt, unsigned int *flag)
 {
   if (!strcmp(opt, "always_check_subject")) {
     *flag |= X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT;
@@ -529,7 +529,7 @@ static int meth_checkhost(lua_State* L)
   max = lua_gettop(L);
   for (i = 3; i <= max; i++) {
     opt = luaL_checkstring(L, i);
-    if (!set_checkhost_flag(opt, &flags)) {
+    if (!lsec_set_checkhost_flag(opt, &flags)) {
       lua_pushnil(L);
       lua_pushfstring(L, "invalid checkhost option (%s)", opt);
       return 2;

--- a/src/x509.h
+++ b/src/x509.h
@@ -25,6 +25,7 @@ typedef t_x509* p_x509;
 
 void  lsec_pushx509(lua_State* L, X509* cert);
 X509* lsec_checkx509(lua_State* L, int idx);
+int   lsec_set_checkhost_flag(const char *opt, unsigned int *flag);
 
 LSEC_API int luaopen_ssl_x509(lua_State *L);
 


### PR DESCRIPTION
verifying the host is quite tedious and hard to get right (wildcards, dns names vs CN, etc). Hence expose the common OpenSSL function `X509_check_host` to offload to that compliant implementation.